### PR TITLE
Docker does not use socket activation anymore

### DIFF
--- a/dcos.tf
+++ b/dcos.tf
@@ -50,7 +50,6 @@ variable "provisioner" {
   default = {
     username = "centos"
     key_name = "dcos-centos"
-    keys_dir = "/Users/rad/Downloads"
     directory = "/home/centos/provisioner" # we need to survive reboots
   }
 }

--- a/provision/bootstrap-machine-init.sh
+++ b/provision/bootstrap-machine-init.sh
@@ -37,7 +37,7 @@ if [ $? != 0 ]; then
 fi
 log "DCOS Zookeeper IP address: ${DCOS_ZK_IP}"
 
-# Pull docs config generator:
+# Pull dcos config generator:
 if [ ! -f dcos_generate_config.sh.downloaded ]; then
   log "Downloading dcos_generate_config.sh file..."
   #wget https://downloads.mesosphere.com/dcos/stable/dcos_generate_config.sh -O dcos_generate_config.sh

--- a/provision/prepare-dcos-machine.sh
+++ b/provision/prepare-dcos-machine.sh
@@ -34,10 +34,10 @@ sudo yum install -y docker-engine wget tar xz unzip curl tree ipset
 # Configure docker:
 log "Creating, enabling and starting Docker service..."
 sudo mkdir -p /etc/systemd/system/docker.service.d
-sudo tee /etc/systemd/system/docker.service.d/override.conf <<EOF 
-[Service] 
-ExecStart= 
-ExecStart=/usr/bin/docker daemon --storage-driver=overlay -H fd:// 
+sudo tee /etc/systemd/system/docker.service.d/override.conf <<EOF
+[Service]
+ExecStart=
+ExecStart=/usr/bin/docker daemon --storage-driver=overlay
 EOF
 
 # Enable docker:


### PR DESCRIPTION
- Ref docker/docker#11135
- Ref jovandeginste/garethr-docker@b608dc6
  => As per docker/docker#11135, we don't seem to need -H fd:// anymore - it crashed our docker setup
- small typo's
- Remove author specific keys directory
  (with these fixes, DC/OS comes up :-)
